### PR TITLE
Fix file input stream leak

### DIFF
--- a/app/src/main/java/com/example/sharefilebc/DriveUploader.kt
+++ b/app/src/main/java/com/example/sharefilebc/DriveUploader.kt
@@ -51,8 +51,7 @@ class DriveUploader(private val context: Context) {
                 } ?: "Unknown File"
 
                 // Read file bytes from Uri
-                val inputStream: InputStream? = context.contentResolver.openInputStream(fileUri)
-                val fileBytes = inputStream?.readBytes() ?: return@withContext null
+                val fileBytes = context.contentResolver.openInputStream(fileUri)?.use { it.readBytes() } ?: return@withContext null
 
                 // Create a new folder for the recipient if it doesn't exist under ShareFileBCApp
                 // まず ShareFileBCApp ルートフォルダのIDを取得または作成


### PR DESCRIPTION
## Summary
- ensure DriveUploader closes file handle while reading

## Testing
- `sh gradlew test` *(fails: Unable to download gradle wrapper due to network)*

------
https://chatgpt.com/codex/tasks/task_e_685041d21c348322ad8bfdf9f515b224