### PR TITLE
Fix delete time by tracking folder upload date

### DIFF
--- a/app/src/main/java/com/example/sharefilebc/DownloadScreen.kt
+++ b/app/src/main/java/com/example/sharefilebc/DownloadScreen.kt
@@ -37,11 +37,11 @@ fun DownloadScreen(initialFolderId: String?) {
     val receivedFolderDao = db.receivedFolderDao()
 
     // ✅ 削除予定時間を計算する関数
-    fun calculateDeleteTime(receivedDate: String): String {
+    fun calculateDeleteTime(uploadDate: String): String {
         return try {
             val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
-            val receivedDateTime = LocalDateTime.parse(receivedDate, formatter)
-            val deleteDateTime = receivedDateTime.plusMinutes(15)
+            val uploadDateTime = LocalDateTime.parse(uploadDate, formatter)
+            val deleteDateTime = uploadDateTime.plusMinutes(15)
             deleteDateTime.format(DateTimeFormatter.ofPattern("HH:mm"))
         } catch (e: Exception) {
             "不明"
@@ -69,6 +69,7 @@ fun DownloadScreen(initialFolderId: String?) {
                         folderId = initialFolderId,
                         folderName = folderStructure.folderName,
                         senderName = folderStructure.senderName,
+                        uploadDate = folderStructure.uploadDate,
                         receivedDate = currentDate,
                         lastAccessDate = currentDate
                     )
@@ -151,7 +152,7 @@ fun DownloadScreen(initialFolderId: String?) {
                                             )
                                             // ✅ 削除予定時間を表示
                                             Text(
-                                                "${calculateDeleteTime(folder.receivedDate)}に削除予定",
+                                                "${calculateDeleteTime(folder.uploadDate)}に削除予定",
                                                 style = MaterialTheme.typography.bodySmall,
                                                 color = MaterialTheme.colorScheme.error
                                             )
@@ -203,7 +204,7 @@ fun DownloadScreen(initialFolderId: String?) {
                                         )
                                         // ✅ フォルダ一覧でも削除予定時間を表示
                                         Text(
-                                            "${calculateDeleteTime(folderItem.receivedDate)}に削除予定",
+                                            "${calculateDeleteTime(folderItem.uploadDate)}に削除予定",
                                             style = MaterialTheme.typography.bodySmall,
                                             color = MaterialTheme.colorScheme.error
                                         )

--- a/app/src/main/java/com/example/sharefilebc/DriveDownloader.kt
+++ b/app/src/main/java/com/example/sharefilebc/DriveDownloader.kt
@@ -27,6 +27,7 @@ data class DriveFileInfo(
 data class FolderStructure(
     val folderName: String,  // 日付フォルダ名
     val senderName: String,  // 送信者名（親フォルダから推測）
+    val uploadDate: String,  // フォルダの作成日時
     val files: List<DriveFileInfo>
 )
 
@@ -68,7 +69,7 @@ class DriveDownloader(private val context: Context) {
 
                 // フォルダ自体の情報を取得
                 val folderInfo = driveService.files().get(folderId)
-                    .setFields("id, name, parents")
+                    .setFields("id, name, parents, createdTime")
                     .execute()
 
                 // 親フォルダの情報を取得して送信者名を推測
@@ -100,9 +101,15 @@ class DriveDownloader(private val context: Context) {
                     )
                 } ?: emptyList()
 
+                val uploadDate = folderInfo.createdTime?.let { created ->
+                    val millis = created.value
+                    java.text.SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(java.util.Date(millis))
+                } ?: java.text.SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(java.util.Date())
+
                 FolderStructure(
                     folderName = folderInfo.name ?: "Unknown Date",
                     senderName = senderName,
+                    uploadDate = uploadDate,
                     files = files
                 )
             } catch (e: Exception) {

--- a/app/src/main/java/com/example/sharefilebc/FileDeleter.kt
+++ b/app/src/main/java/com/example/sharefilebc/FileDeleter.kt
@@ -32,10 +32,10 @@ object FileDeleter {
 
         val expired = allFolders.filter { entry ->
             try {
-                val entryDate = LocalDateTime.parse(entry.receivedDate, formatter)
+                val entryDate = LocalDateTime.parse(entry.uploadDate, formatter)
                 entryDate.isBefore(now.minusMinutes(15)) // ✅ 15分に変更
             } catch (e: Exception) {
-                Log.e("FileDeleter", "日付解析エラー: ${entry.receivedDate}", e)
+                Log.e("FileDeleter", "日付解析エラー: ${entry.uploadDate}", e)
                 false
             }
         }

--- a/app/src/main/java/com/example/sharefilebc/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/sharefilebc/data/AppDatabase.kt
@@ -5,8 +5,8 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 
-// バージョンを4に設定します (ReceivedFolderEntity 追加のため)
-@Database(entities = [UserEntity::class, SharedFolderEntity::class, ReceivedFolderEntity::class], version = 4) // ★ここも ReceivedFolderEntity に修正
+// バージョンを5に設定します (uploadDate 追加のため)
+@Database(entities = [UserEntity::class, SharedFolderEntity::class, ReceivedFolderEntity::class], version = 5)
 abstract class AppDatabase : RoomDatabase() {
     // 抽象メソッドとして、各DAOへのアクセスを提供する
     abstract fun userDao(): UserDao

--- a/app/src/main/java/com/example/sharefilebc/data/ReceivedFolderEntity.kt
+++ b/app/src/main/java/com/example/sharefilebc/data/ReceivedFolderEntity.kt
@@ -9,6 +9,7 @@ data class ReceivedFolderEntity(
     val folderId: String,          // Google DriveのフォルダID
     val folderName: String,        // フォルダ名（日付など）
     val senderName: String,        // 送信者名（フォルダ構造から推測）
+    val uploadDate: String,        // アップロード日時
     val receivedDate: String,      // 受信日時
     val lastAccessDate: String     // 最後にアクセスした日時
 )


### PR DESCRIPTION
## Summary
- track uploadDate in ReceivedFolderEntity
- fetch folder createdTime in DriveDownloader
- show deletion time based on uploadDate in DownloadScreen
- purge expired folders using uploadDate
- bump Room DB version to 5

## Testing
- `./gradlew test` *(fails: Unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_685043f59d848322aee384178de29164