### PR TITLE
Add file picker chooser

### DIFF
--- a/app/src/main/java/com/example/sharefilebc/FilePickerContract.kt
+++ b/app/src/main/java/com/example/sharefilebc/FilePickerContract.kt
@@ -1,0 +1,30 @@
+package com.example.sharefilebc
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.MediaStore
+import androidx.activity.result.contract.ActivityResultContract
+
+/**
+ * 画像ギャラリーと一般的なファイルマネージャの両方からファイルを選択できる契約。
+ */
+class FilePickerContract : ActivityResultContract<Unit, Uri?>() {
+    override fun createIntent(context: Context, input: Unit): Intent {
+        val pickImageIntent = Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI).apply {
+            type = "image/*"
+        }
+        val getContentIntent = Intent(Intent.ACTION_GET_CONTENT).apply {
+            addCategory(Intent.CATEGORY_OPENABLE)
+            type = "*/*"
+        }
+        return Intent.createChooser(getContentIntent, "ファイルを選択").apply {
+            putExtra(Intent.EXTRA_INITIAL_INTENTS, arrayOf(pickImageIntent))
+        }
+    }
+
+    override fun parseResult(resultCode: Int, intent: Intent?): Uri? {
+        return if (resultCode == Activity.RESULT_OK) intent?.data else null
+    }
+}

--- a/app/src/main/java/com/example/sharefilebc/HomeScreen.kt
+++ b/app/src/main/java/com/example/sharefilebc/HomeScreen.kt
@@ -4,7 +4,6 @@ import android.net.Uri
 import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -12,6 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import com.example.sharefilebc.FilePickerContract
 import com.example.sharefilebc.data.AppDatabase
 import com.example.sharefilebc.data.UserEntity
 import kotlinx.coroutines.Dispatchers
@@ -38,7 +38,7 @@ fun HomeScreen(
     var isUploading by remember { mutableStateOf(false) }
 
     val openFileLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.GetContent(),
+        contract = FilePickerContract(),
         onResult = { uri: Uri? ->
             uri?.let { fileUri ->
                 selectedUser?.let { user ->
@@ -136,7 +136,7 @@ fun HomeScreen(
                 Button(
                     onClick = {
                         selectedUser = user
-                        openFileLauncher.launch("*/*")
+                        openFileLauncher.launch(Unit)
                     },
                     modifier = Modifier.weight(1f),
                     enabled = !isUploading


### PR DESCRIPTION
## Summary
- create a custom `FilePickerContract` that shows a chooser with gallery and file manager
- use the new contract in `HomeScreen` so users can pick from either source

## Testing
- `./gradlew test` *(fails: unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686831a6bcbc83228d15ca7084265ea1