### PR TITLE
トークン閾値／送金量の設定ページ

### DIFF
--- a/app/src/main/java/com/example/sharefilebc/AccountScreen.kt
+++ b/app/src/main/java/com/example/sharefilebc/AccountScreen.kt
@@ -1,8 +1,9 @@
-package com.example.sharefilebc.ui
+package com.example.sharefilebc
 
-import android.widget.NumberPicker
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,6 +15,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -21,14 +24,12 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -41,12 +42,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import com.example.sharefilebc.ui.theme.ModalOverlay
+import com.example.sharefilebc.ui.theme.PureWhite
 import com.example.sharefilebc.ui.theme.rememberAvatarColors
+import kotlin.math.abs
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AccountScreen(
     name: String?,
@@ -192,7 +194,7 @@ fun AccountScreen(
 
                     TokenSettingRow(
                         title = "トークン閾値",
-                        value = "$tokenThreshold 1 TPC".replace("1 1", "1"),
+                        value = "$tokenThreshold TPC",
                         onClick = { showThresholdPicker = true }
                     )
 
@@ -200,7 +202,7 @@ fun AccountScreen(
 
                     TokenSettingRow(
                         title = "送金量",
-                        value = "$sendFee 1 TPC".replace("1 1", "1"),
+                        value = "$sendFee TPC",
                         onClick = { showSendFeePicker = true }
                     )
                 }
@@ -462,7 +464,7 @@ private fun PublicKeyListDialog(onClose: () -> Unit) {
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun NumberPickerSheet(
     title: String,
@@ -472,55 +474,130 @@ private fun NumberPickerSheet(
     onConfirm: (Int) -> Unit
 ) {
     var currentValue by remember { mutableStateOf(initialValue.coerceIn(range)) }
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val values = remember(range) { range.toList() }
+    val pickerHeight = 200.dp
+    val itemHeight = 48.dp
+    val listState = rememberLazyListState(initialFirstVisibleItemIndex = values.indexOf(currentValue))
+    val flingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
 
-    ModalBottomSheet(
+    Dialog(
         onDismissRequest = onDismiss,
-        sheetState = sheetState,
-        containerColor = accountCardBackground()
+        properties = DialogProperties(usePlatformDefaultWidth = false)
     ) {
-        Column(
+        // ★ 背景：アカウントページの上に半透明黒で重ねる
+        Box(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 20.dp, vertical = 16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
+                .fillMaxSize()
+                .background(ModalOverlay),
+            contentAlignment = Alignment.Center
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 32.dp),
+                shape = RoundedCornerShape(22.dp),
+                colors = CardDefaults.cardColors(containerColor = PureWhite),
+                elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
             ) {
-                TextButton(onClick = onDismiss) { Text("キャンセル") }
-                Spacer(modifier = Modifier.weight(1f))
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.titleLarge,
-                    fontWeight = FontWeight.Black,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.weight(1f)
-                )
-                Spacer(modifier = Modifier.weight(1f))
-                TextButton(onClick = { onConfirm(currentValue) }) { Text("完了") }
-            }
-
-            Spacer(Modifier.height(12.dp))
-
-            AndroidView(
-                modifier = Modifier.fillMaxWidth(),
-                factory = { context ->
-                    NumberPicker(context).apply {
-                        minValue = range.first
-                        maxValue = range.last
-                        value = currentValue
-                        wrapSelectorWheel = false
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        TextButton(onClick = onDismiss) {
+                            Text("キャンセル", color = MaterialTheme.colorScheme.primary)
+                        }
+                        Spacer(modifier = Modifier.weight(1f))
+                        TextButton(onClick = { onConfirm(currentValue) }) {
+                            Text("完了", color = MaterialTheme.colorScheme.primary)
+                        }
                     }
-                },
-                update = { picker ->
-                    picker.value = currentValue
-                    picker.setOnValueChangedListener { _, _, newVal ->
-                        currentValue = newVal
+
+                    Spacer(Modifier.height(4.dp))
+
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.headlineSmall.copy(
+                            fontWeight = FontWeight.Black
+                        ),
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+
+                    Spacer(Modifier.height(12.dp))
+
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(pickerHeight)
+                    ) {
+                        LazyColumn(
+                            state = listState,
+                            flingBehavior = flingBehavior,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .align(Alignment.Center),
+                            contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                                vertical = (pickerHeight - itemHeight) / 2
+                            )
+                        ) {
+                            items(values.size) { index ->
+                                val distance = abs(values[index] - currentValue)
+                                val alpha = when (distance) {
+                                    0 -> 1f
+                                    1 -> 0.5f
+                                    else -> 0.3f
+                                }
+
+                                Text(
+                                    text = values[index].toString(),
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .height(itemHeight),
+                                    textAlign = TextAlign.Center,
+                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = alpha),
+                                    fontSize = 22.sp,
+                                    fontWeight = if (distance == 0) FontWeight.Bold else FontWeight.Medium
+                                )
+                            }
+                        }
+
+                        // 中央の選択行ハイライト
+                        Box(
+                            modifier = Modifier
+                                .align(Alignment.Center)
+                                .fillMaxWidth()
+                                .height(itemHeight)
+                                .clip(RoundedCornerShape(12.dp))
+                                .background(
+                                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.05f)
+                                )
+                        )
+                    }
+
+                    // スクロール位置から currentValue を更新
+                    LaunchedEffect(
+                        listState.firstVisibleItemIndex,
+                        listState.firstVisibleItemScrollOffset
+                    ) {
+                        val viewportHeight =
+                            listState.layoutInfo.viewportEndOffset - listState.layoutInfo.viewportStartOffset
+                        if (viewportHeight <= 0) return@LaunchedEffect
+                        val center =
+                            listState.layoutInfo.viewportStartOffset + viewportHeight / 2
+                        val closest = listState.layoutInfo.visibleItemsInfo.minByOrNull { item ->
+                            val itemCenter = item.offset + item.size / 2
+                            abs(itemCenter - center)
+                        }
+                        closest?.let { currentValue = values[it.index] }
                     }
                 }
-            )
+            }
         }
     }
 }
@@ -530,7 +607,7 @@ private fun SignOutConfirmDialog(
     onDismiss: () -> Unit,
     onConfirm: () -> Unit
 ) {
-    // カスタムダイアログ：左右に余白を持たせて中央寄せ
+    // 背景：半透明黒、中央カード：白
     Dialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false)
@@ -538,14 +615,14 @@ private fun SignOutConfirmDialog(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(Color(0x66000000)),
+                .background(ModalOverlay),
             contentAlignment = Alignment.Center
         ) {
             Card(
                 modifier = Modifier.padding(horizontal = 32.dp),
                 shape = RoundedCornerShape(24.dp),
                 colors = CardDefaults.cardColors(
-                    containerColor = Color(0xFFE5F0FF)
+                    containerColor = PureWhite
                 )
             ) {
                 Column(

--- a/app/src/main/java/com/example/sharefilebc/HomeScreen.kt
+++ b/app/src/main/java/com/example/sharefilebc/HomeScreen.kt
@@ -68,8 +68,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.example.sharefilebc.data.AppDatabase
 import com.example.sharefilebc.data.UserEntity
-import com.example.sharefilebc.ui.AccountAvatar
-import com.example.sharefilebc.ui.AccountScreen
 import com.example.sharefilebc.ui.theme.HomeScreenButtonColors
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions

--- a/app/src/main/java/com/example/sharefilebc/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/sharefilebc/ui/theme/Color.kt
@@ -2,48 +2,81 @@ package com.example.sharefilebc.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
+/* ----------------------------------------------------------
+ *  iOS 風デザインで共通して使う色
+ * ---------------------------------------------------------- */
+
+/** 🔵 iOS純正の青色（全画面でこれを使う） */
+val IosBlue = Color(0xFF0A84FF)
+
+/** 🔴 iOS純正エラー色 */
+val IosRed = Color(0xFFFF3B30)
+
+/** 🔳 半透明の黒（モーダル背景用 - アカウントページ透ける） */
+val ModalOverlay = Color(0x66000000)
+
+/** ⚪ 白 */
+val PureWhite = Color(0xFFFFFFFF)
+
+/** iOSの「超薄い灰色」背景 (#F2F2F7) */
+val IosGroupedBG = Color(0xFFF2F2F7)
+
+/** iOSのカード背景（白） */
+val IosCardBG = Color(0xFFFFFFFF)
+
+/** iOSの淡い境界線グレー */
+val IosSeparator = Color(0xFFC6C6C8)
+
+/** iOSの文字グレー */
+val IosTextGray = Color(0xFF3A3A3C)
+
+/* ----------------------------------------------------------
+ * MaterialTheme に紐づく値（必要に応じて IosBlue を参照）
+ * ---------------------------------------------------------- */
+
 /* -------- Light (iOSライク) -------- */
-val md_theme_light_primary = Color(0xFF0A84FF)
-val md_theme_light_onPrimary = Color(0xFFFFFFFF)
+val md_theme_light_primary = IosBlue
+val md_theme_light_onPrimary = Color.White
 
 val md_theme_light_secondary = Color(0xFF30D158)
-val md_theme_light_onSecondary = Color(0xFF000000)
+val md_theme_light_onSecondary = Color.Black
 
 val md_theme_light_tertiary = Color(0xFFFF9F0A)
-val md_theme_light_onTertiary = Color(0xFF000000)
+val md_theme_light_onTertiary = Color.Black
 
-val md_theme_light_background = Color(0xFFF2F2F7)   // grouped 背景
-val md_theme_light_onBackground = Color(0xFF000000)
+val md_theme_light_background = IosGroupedBG
+val md_theme_light_onBackground = Color.Black
 
-val md_theme_light_surface = Color(0xFFFFFFFF)      // カード/シート/ボトムバーなど白基調
-val md_theme_light_onSurface = Color(0xFF000000)
+val md_theme_light_surface = IosCardBG
+val md_theme_light_onSurface = Color.Black
 
 val md_theme_light_surfaceVariant = Color(0xFFEFEFF4)
-val md_theme_light_onSurfaceVariant = Color(0xFF3A3A3C)
+val md_theme_light_onSurfaceVariant = IosTextGray
 
-val md_theme_light_outline = Color(0xFFC6C6C8)
+val md_theme_light_outline = IosSeparator
 
-val md_theme_light_error = Color(0xFFFF3B30)
-val md_theme_light_onError = Color(0xFFFFFFFF)
+val md_theme_light_error = IosRed
+val md_theme_light_onError = Color.White
 
-/* === 追加: ナビゲーション用の無効アイコン色（iOS系グレー） === */
+/* -------- ナビバーなどの非アクティブアイコン -------- */
 val md_nav_light_icon_inactive = Color(0xFF8E8E93)
 
+
 /* -------- Dark (iOSライク) -------- */
-val md_theme_dark_primary = Color(0xFF0A84FF)
-val md_theme_dark_onPrimary = Color(0xFF000000)
+val md_theme_dark_primary = IosBlue
+val md_theme_dark_onPrimary = Color.Black
 
 val md_theme_dark_secondary = Color(0xFF30D158)
-val md_theme_dark_onSecondary = Color(0xFF000000)
+val md_theme_dark_onSecondary = Color.Black
 
 val md_theme_dark_tertiary = Color(0xFFFF9F0A)
-val md_theme_dark_onTertiary = Color(0xFF000000)
+val md_theme_dark_onTertiary = Color.Black
 
 val md_theme_dark_background = Color(0xFF1C1C1E)
-val md_theme_dark_onBackground = Color(0xFFFFFFFF)
+val md_theme_dark_onBackground = Color.White
 
 val md_theme_dark_surface = Color(0xFF2C2C2E)
-val md_theme_dark_onSurface = Color(0xFFFFFFFF)
+val md_theme_dark_onSurface = Color.White
 
 val md_theme_dark_surfaceVariant = Color(0xFF1F1F21)
 val md_theme_dark_onSurfaceVariant = Color(0xFFEBEBF5)
@@ -51,56 +84,49 @@ val md_theme_dark_onSurfaceVariant = Color(0xFFEBEBF5)
 val md_theme_dark_outline = Color(0xFF3A3A3C)
 
 val md_theme_dark_error = Color(0xFFFF453A)
-val md_theme_dark_onError = Color(0xFF000000)
+val md_theme_dark_onError = Color.Black
 
-/* === 追加: ダーク時の無効アイコン色（やや明るめグレー） === */
 val md_nav_dark_icon_inactive = Color(0xFF9FA3A8)
 
-/* -------- Shared Screen Custom Palette -------- */
+
+/* ----------------------------------------------------------
+ *  Shared Screen Custom Palette
+ * ---------------------------------------------------------- */
+
 object SharedScreenColors {
     val Background = md_theme_light_surfaceVariant
-    val TabSelected = Color(0xFFFFFFFF)
+    val TabSelected = Color.White
     val TabUnselected = Color(0xFFD1D1D6)
-    val UserCardBackground = Color(0xFFFFFFFF)
+    val UserCardBackground = Color.White
     val UserCardBorder = Color(0xFFDDDEE3)
     val UserEmail = Color(0xFF8E8E93)
     val DateLabel = Color(0xFF8E8E93)
 }
 
-/* -------- Home Screen Controls -------- */
+/* ----------------------------------------------------------
+ *  Home Screen Controls
+ * ---------------------------------------------------------- */
+
 object HomeScreenButtonColors {
     val BalanceButtonBackgroundLight = Color(0xFFE5E5EA)
     val BalanceButtonBackgroundDark = Color(0xFF3A3A3C)
-    val BalanceButtonContent = Color(0xFF000000)
+    val BalanceButtonContent = Color.Black
 }
 
-/* -------- Account Avatar Palettes (Googleサービスに近い配色) -------- */
+/* ----------------------------------------------------------
+ *  Avatar Colors (Google系）
+ * ---------------------------------------------------------- */
+
 val AvatarPaletteLight = listOf(
-    Color(0xFFDB4437), // Google Red 500
-    Color(0xFFF4B400), // Google Yellow 500
-    Color(0xFF0F9D58), // Google Green 500
-    Color(0xFF4285F4), // Google Blue 500
-    Color(0xFFAB47BC), // Purple 400
-    Color(0xFF00ACC1), // Cyan 600
-    Color(0xFF5E35B1), // Deep Purple 600
-    Color(0xFFF09300), // Orange 600
-    Color(0xFF7CB342), // Light Green 600
-    Color(0xFF00897B), // Teal 600
-    Color(0xFF795548), // Brown 500
-    Color(0xFF546E7A)  // Blue Grey 600
+    Color(0xFFDB4437), Color(0xFFF4B400), Color(0xFF0F9D58),
+    Color(0xFF4285F4), Color(0xFFAB47BC), Color(0xFF00ACC1),
+    Color(0xFF5E35B1), Color(0xFFF09300), Color(0xFF7CB342),
+    Color(0xFF00897B), Color(0xFF795548), Color(0xFF546E7A)
 )
 
 val AvatarPaletteDark = listOf(
-    Color(0xFFF28B82),
-    Color(0xFFFDE293),
-    Color(0xFF81C995),
-    Color(0xFFAECBFA),
-    Color(0xFFD7AEFB),
-    Color(0xFF80DEEA),
-    Color(0xFFB39DDB),
-    Color(0xFFF6AD70),
-    Color(0xFFC5E1A5),
-    Color(0xFF8DDAD5),
-    Color(0xFFBCAAA4),
-    Color(0xFF9AA0A6)
+    Color(0xFFF28B82), Color(0xFFFDE293), Color(0xFF81C995),
+    Color(0xFFAECBFA), Color(0xFFD7AEFB), Color(0xFF80DEEA),
+    Color(0xFFB39DDB), Color(0xFFF6AD70), Color(0xFFC5E1A5),
+    Color(0xFF8DDAD5), Color(0xFFBCAAA4), Color(0xFF9AA0A6)
 )


### PR DESCRIPTION
トークン閾値／送金量をタップした際、上部から表示されるカード型ダイアログに「キャンセル」「完了」ボタンとタイトルを配置し、指定デザインに合わせた。

スナップ付きの縦スクロールリストで数字を選択できるようにし、中央行をハイライトしつつ周辺の数字を淡色で表示するスタイルを実装した。